### PR TITLE
Adding .pre-commit-hooks.yaml to enable pre-commit hooking, https://p…

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,5 @@
+-   id: cfn_nag
+    name: stelligent cfn_nag
+    description: The cfn-nag tool looks for patterns in CloudFormation templates that may indicate insecure infrastructure.
+    entry: cfn_nag
+    language: ruby


### PR DESCRIPTION
To support usage with git pre-commit hooks, using the [pre-commit](https://pre-commit.com), there has to be `.pre-commit-hooks.yaml`

`
-   id: cfn_nag
    name: stelligent cfn_nag
    description: The cfn-nag tool looks for patterns in CloudFormation templates that may indicate insecure infrastructure.
    entry: cfn_nag
    language: ruby
`